### PR TITLE
turn AFLive OFF before requesting AFLive ON

### DIFF
--- a/livethread.cpp
+++ b/livethread.cpp
@@ -703,6 +703,8 @@ bool GMyLiveThread::processCommand()
 		{
 #ifdef EDSDK
 			EdsEvfAFMode mode = (EdsEvfAFMode)param1;
+			// first try to turn off AF
+			err = EdsSendCommand(camera, kEdsCameraCommand_DoEvfAf, kEdsCameraCommand_EvfAf_OFF);
 			err = EdsSendCommand(camera, kEdsCameraCommand_DoEvfAf, mode);
 #endif
 #ifdef GPHOTO2


### PR DESCRIPTION
this fixes one-time only Camera Live AF for EOS500D